### PR TITLE
Name the api description interceptor.

### DIFF
--- a/src/vase/routes.clj
+++ b/src/vase/routes.clj
@@ -12,7 +12,8 @@
   string value"
   [routes]
   (i/interceptor
-   {:enter (fn [context]
+   {:name :describe-api
+    :enter (fn [context]
              (let [{:keys [f sep edn]
                     :or {f "" sep "<br/>" edn false}} (get-in context [:request :query-params])
                    results (mapv #(take 2 %) routes)]


### PR DESCRIPTION
In general, I think it's useful to name all interceptors. In this case, naming this interceptor allows the `make-interceptors-fn` to easily check if it's present in the interceptor chain.
