### PR TITLE
Uniquely name the describe-api interceptor.

### DIFF
--- a/src/vase/routes.clj
+++ b/src/vase/routes.clj
@@ -12,7 +12,7 @@
   string value"
   [routes]
   (i/interceptor
-   {:name (keyword (str (gensym) "-describe-api"))
+   {:name (keyword "vase" (str (gensym "describe-api-")))
     :enter (fn [context]
              (let [{:keys [f sep edn]
                     :or {f "" sep "<br/>" edn false}} (get-in context [:request :query-params])


### PR DESCRIPTION
Since this interceptor is created programmatically, it's name should be unique.
