### PR TITLE
Throw an exception if the db-op is invalid

### DIFF
--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -83,11 +83,13 @@
 
 (def db-ops
   {:vase/assert-entity  `process-assert
-   :vase/retract-entity `process-retract})
+   :vase/retract-entity `process-retract
+   nil                  `process-assert})
 
 (defn tx-processor
   [op]
-  (get db-ops op `process-assert))
+  (or (get db-ops op)
+      (throw (ex-info "Unknown db-op" {:db-op op}))))
 
 (defn merged-parameters
   [request]


### PR DESCRIPTION
This may be better implemented as a spec for the descriptor that's checked e.g. at system start. I would, in fact, be happy to take a stab at that if there is interest.