### PR TITLE
Introducing the #vase/conform action

### DIFF
--- a/docs/action_literals.md
+++ b/docs/action_literals.md
@@ -13,63 +13,94 @@ for #vase/respond and #vase/redirect. To chain literals, put them in a vector.
 Immediately send an HTTP response. This cannot be chained together
 with any other literals.
 
-| Param | Meaning |
-| ----- | --------|
-| :name | Name of the interceptor. Required. |
-| :params | Symbols to bind from `:params`. |
-| :headers | Any extra headers to merge with the defaults. |
+| Param       | Meaning                                                   |
+|-------------|-----------------------------------------------------------|
+| :name       | Name of the interceptor. Required.                        |
+| :params     | Symbols to bind from `:params`.                           |
+| :headers    | Any extra headers to merge with the defaults.             |
 | :edn-coerce | Symbols that should be parsed as EDN data before binding. |
-| :body | An expression that produces the body of the response |
-| :status  | The HTTP status code to return |
+| :body       | An expression that produces the body of the response      |
+| :status     | The HTTP status code to return                            |
 
 ## #vase/redirect
 
-Immediately send a 302 redirect response to the client.
+Immediately send a 302 redirect response to the client. This cannot be
+chained together with any other literals.
 
-| Param | Meaning |
-|-------|---------|
-| :name | Name of the interceptor. Required. |
-| :params | Symbols to bind from `:params`. |
-| :headers | Any extra headers to merge with the defaults. |
-| :body | The body of the response |
-| :status  | The HTTP status code to return |
+| Param    | Meaning                                                                                   |
+|----------|-------------------------------------------------------------------------------------------|
+| :name    | Name of the interceptor. Required.                                                        |
+| :params  | Symbols to bind from `:params`.                                                           |
+| :headers | Any extra headers to merge with the defaults.                                             |
+| :body    | The body of the response                                                                  |
+| :status  | The HTTP status code to return                                                            |
 | :url     | An expression that produces a URL. This will be the "Location" header sent to the client. |
 
 ## #vase/validate
 
 Apply specs to the inputs.
 
-| Param | Meaning |
-|-------|---------|
-| :name | Name of the interceptor. Required. |
-| :params | Symbols to bind from `:params`. |
-| :headers | Any extra headers to merge with the defaults. |
-| :spec    | The spec to apply. Must be registered before this action executes.  |
-| :request-params-path | Instead of locating parameters directly in the :request, use this path to navigate through nested maps.  |
+| Param                | Meaning                                                                                                 |
+|----------------------|---------------------------------------------------------------------------------------------------------|
+| :name                | Name of the interceptor. Required.                                                                      |
+| :params              | Symbols to bind from `:params`.                                                                         |
+| :headers             | Any extra headers to merge with the defaults.                                                           |
+| :spec                | The spec to apply. Must be registered before this action executes.                                      |
+| :request-params-path | Instead of locating parameters directly in the :request, use this path to navigate through nested maps. |
+
+If validate is the last interceptor _or_ if any of the specs fail, it will
+generate a response.
+
+## #vase/conform
+
+Apply specs to data on the context, reattaching the conformed data to
+the context.
+
+| Param       | Meaining                                                                                                                                  |
+|-------------|-------------------------------------------------------------------------------------------------------------------------------------------|
+| :name       | Name of the interceptor.                                                                                                                  |
+| :from       | The context map key where data will be found.                                                                                             |
+| :spec       | The spec to apply. Must be registered before this action executes.                                                                        |
+| :to         | The context map key where the conformed data will be attached.                                                                            |
+| :explain-to | The context map key where explain-data will be attached if the data fails the spec. Defaults to :com.cognitect.vase.actions/explain-data. |
 
 ## #vase/query
 
 Run a datalog query and return the results as JSON
 
-| Param | Meaning |
-|-------|---------|
-| :name | Name of the interceptor. Required. |
-| :params | Symbols to bind from `:params`. |
-| :headers | Any extra headers to merge with the defaults. |
-| :edn-coerce | Symbols that should be parsed as EDN data before binding. |
-| :query | A datalog query expression. Has access to symbols from `params`, in order, in the `:in` clause. |
-| :constants | Additional values to be passed to the query, following all the parameters. |
+| Param       | Meaning                                                                                                           |
+|-------------|------------------------------------------------------------------------------------------------------------------ |
+| :name       | Name of the interceptor. Required.                                                                                |
+| :params     | Symbols to bind from `:params`.                                                                                   |
+| :headers    | Any extra headers to merge with the defaults.                                                                     |
+| :edn-coerce | Symbols that should be parsed as EDN data before binding.                                                         |
+| :query      | A datalog query expression. Has access to symbols from `params`, in order, in the `:in` clause.                   |
+| :constants  | Additional values to be passed to the query, following all the parameters.                                        |
+| :to         | The context map key where the query results will be attached. Defaults to :com.cognitect.vase.actions/query-data  |
+
+If this is the last interceptor in the chain, it generates a response.
+
+If this is not the last interceptor in the chain, it attaches the
+query results to the context map at the `:to` key
 
 ## #vase/transact
 
-Execute a Datomic transaction. Return the results (the tx-result) as JSON. The new database value will be used for any subsequent datalog queries.
+Execute a Datomic transaction. Return the results (the tx-result) as
+JSON. The new database value will be used for any subsequent datalog
+queries.
 
-| Param | Meaning |
-|-------|---------|
-| :name | Name of the interceptor. Required. |
-| :properties | Whitelist of parameters to accept from the client |
-| :headers | Any extra headers to merge with the defaults. |
-| :db-op | Either :vase/assert-entity or :vase/retract-entity. Defaults to :vase/assert-entity. |
+| Param       | Meaning                                                                                                                    |
+|-------------|--------------------------------------------------------------------------------------------------------------------------- |
+| :name       | Name of the interceptor. Required.                                                                                         |
+| :properties | Whitelist of parameters to accept from the client                                                                          |
+| :headers    | Any extra headers to merge with the defaults.                                                                              |
+| :db-op      | Either :vase/assert-entity or :vase/retract-entity. Defaults to :vase/assert-entity.                                       |
+| :to         | The context map key where the transaction results will be attached. Defaults to :com.cognitect.vase.actions/transact-data  |
+
+If this is the last interceptor in the chain, it generates a response.
+
+If this is not the last interceptor in the chain, it attaches the
+transaction result to the context map at the `:to` key.
 
 ## #vase/intercept
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject com.cognitect/pedestal.vase "0.9.0"
+(defproject com.cognitect/pedestal.vase "0.9.1-SNAPSHOT"
   :description "Vase: Pedestal API Container"
   :url "https://github.com/cognitect-labs/pedestal.vase"
   :dependencies [;; Platform

--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -256,12 +256,11 @@
        (let [val#           (get ~'context ~from)
              conformed#     (clojure.spec/conform ~spec val#)
              problems#      (when (= :clojure.spec/invalid conformed#)
-                              (clojure.spec/explain-data ~spec val#))]
-         (cond->
-             (assoc ~'context ~to conformed#)
-
-           (some? problems#)
-           (assoc ~explain-to problems#))))))
+                              (clojure.spec/explain-data ~spec val#))
+             ctx# (assoc ~'context ~to conformed#)]
+         (if problems#
+           (assoc ctx# ~explain-to problems#)
+           ctx#)))))
 
 (defn conform-action
   "Returns a Pedestal interceptor that performs conforms data from the context.

--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -246,6 +246,39 @@
       :action-literal
       :vase/validate})))
 
+(defn conform-action-exprs
+  "Return code for a Pedestal interceptor function that performs
+  clojure.spec validation on the data attached at `from`. If the data
+  does not conform, the explain-data will be attached at `explain-to`"
+  [from spec to explain-to]
+  (let [explain-to (or explain-to ::explain-data)]
+    `(fn [{~'request :request :as ~'context}]
+       (let [val#           (get ~'context ~from)
+             conformed#     (clojure.spec/conform ~spec val#)
+             problems#      (when (= :clojure.spec/invalid conformed#)
+                              (clojure.spec/explain-data ~spec val#))]
+         (cond->
+             (assoc ~'context ~to conformed#)
+
+           (some? problems#)
+           (assoc ~explain-to problems#))))))
+
+(defn conform-action
+  "Returns a Pedestal interceptor that performs conforms data from the context.
+
+  The interceptor will take data from the key named in `:from`,
+  conform it according to the specs in `:spec` and reattach it to the
+  context under the key named in `:to`."
+  [name from spec to explain-to]
+  (dynamic-interceptor
+   name
+   :conform
+   {:enter
+    (conform-action-exprs from spec to explain-to)
+
+    :action-literal
+    :vase/conform}))
+
 (defn query-action-exprs
   "Return code for a Pedestal interceptor function that performs a
   Datomic query.
@@ -270,8 +303,9 @@
 
   `headers` is an expression that evaluates to a map of header
   name (string) to header value (string). May be nil."
-  [query variables coercions constants headers]
-  (let [args-sym (gensym 'args)]
+  [query variables coercions constants headers to]
+  (let [args-sym (gensym 'args)
+        to       (or to ::query-data)]
     `(fn [{~'request :request :as ~'context}]
        (let [~args-sym      (merged-parameters ~'request)
              vals#          [~(mapcat
@@ -301,7 +335,7 @@
                                400))]
          (if (empty? (:io.pedestal.interceptor.chain/queue ~'context))
            (assoc ~'context :response resp#)
-           (assoc ~'context ::query-data response-body#))))))
+           (assoc ~'context ~to response-body#))))))
 
 (comment
   (clojure.pprint/pprint
@@ -320,12 +354,12 @@
 (defn query-action
   "Returns a Pedestal interceptor that executes a Datomic query on
   entry."
-  [name query variables coercions constants headers]
+  [name query variables coercions constants headers to]
   (dynamic-interceptor
    name
    :query
    {:enter
-    (query-action-exprs query variables coercions constants headers)
+    (query-action-exprs query variables coercions constants headers to)
 
     :action-literal
     :vase/query}))
@@ -344,37 +378,38 @@
 
   `headers` is an expression that evaluates to a map of header
   name (string) to header value (string). May be nil."
-  [properties db-op headers]
-  `(fn [{~'request :request :as ~'context}]
-     (let [;args#          (merged-parameters ~'request)
-           args#          (mapv
-                           #(select-keys % ~(vec properties))
-                           (get-in ~'request [:json-params :payload]))
-           tx-data#       (~(tx-processor db-op) args#)
-           conn#          (:conn ~'request)
-           response-body# (apply-tx
-                           conn#
-                           tx-data#
-                           args#)
-           resp#          (util/response
-                           response-body#
-                           ~headers
-                           (util/status-code response-body# (:errors ~'context)))]
-       (if (empty? (:io.pedestal.interceptor.chain/queue ~'context))
-         (assoc ~'context :response resp#)
-         (-> ~'context
-             (assoc ::transact-data response-body#)
-             (assoc-in [:request :db] (d/db conn#)))))))
+  [properties db-op headers to]
+  (let [to (or to ::transact-data)]
+    `(fn [{~'request :request :as ~'context}]
+       (let [;args#          (merged-parameters ~'request)
+             args#          (mapv
+                             #(select-keys % ~(vec properties))
+                             (get-in ~'request [:json-params :payload]))
+             tx-data#       (~(tx-processor db-op) args#)
+             conn#          (:conn ~'request)
+             response-body# (apply-tx
+                             conn#
+                             tx-data#
+                             args#)
+             resp#          (util/response
+                             response-body#
+                             ~headers
+                             (util/status-code response-body# (:errors ~'context)))]
+         (if (empty? (:io.pedestal.interceptor.chain/queue ~'context))
+           (assoc ~'context :response resp#)
+           (-> ~'context
+               (assoc ~to response-body#)
+               (assoc-in [:request :db] (d/db conn#))))))))
 
 (defn transact-action
   "Returns a Pedestal interceptor that executes a Datomic transaction
   on entry."
-  [name properties db-op headers]
+  [name properties db-op headers to]
   (dynamic-interceptor
    name
    :transact
    {:enter
-    (transact-action-exprs properties db-op headers)
+    (transact-action-exprs properties db-op headers to)
 
     :action-literal
     :vase/transact}))

--- a/src/com/cognitect/vase/literals.clj
+++ b/src/com/cognitect/vase/literals.clj
@@ -86,10 +86,22 @@
 (defmethod print-method ValidateAction [t ^java.io.Writer w]
   (.write w (str "#vase/validate" (into {} t))))
 
-(defrecord QueryAction [name params query edn-coerce constants headers doc]
+(defrecord ConformAction [name from spec to explain-to doc]
   i/IntoInterceptor
   (-interceptor [_]
-    (actions/query-action name query params (into #{} edn-coerce) constants headers)))
+    (actions/conform-action name from spec to explain-to)))
+
+(defn conform [form]
+  {:pre [(map? form)]}
+  (map->ConformAction form))
+
+(defmethod print-method ConformAction [t ^java.io.Writer w]
+  (.write w (str "#vase/conform" (into {} t))))
+
+(defrecord QueryAction [name params query edn-coerce constants headers to doc]
+  i/IntoInterceptor
+  (-interceptor [_]
+    (actions/query-action name query params (into #{} edn-coerce) constants headers to)))
 
 (defn query [form]
   {:pre [(map? form)
@@ -102,10 +114,10 @@
 (defmethod print-method QueryAction [t ^java.io.Writer w]
   (.write w (str "#vase/query" (into {} t))))
 
-(defrecord TransactAction [name properties db-op headers doc]
+(defrecord TransactAction [name properties db-op headers to doc]
   i/IntoInterceptor
   (-interceptor [_]
-    (actions/transact-action name properties db-op headers)))
+    (actions/transact-action name properties db-op headers to)))
 
 (defn transact [form]
   {:pre [(map? form)
@@ -134,4 +146,3 @@
                      :enter enter
                      :leave leave
                      :error error})))
-

--- a/src/data_readers.clj
+++ b/src/data_readers.clj
@@ -1,5 +1,6 @@
 {vase/respond     com.cognitect.vase.literals/respond
  vase/redirect    com.cognitect.vase.literals/redirect
+ vase/conform     com.cognitect.vase.literals/conform
  vase/query       com.cognitect.vase.literals/query
  vase/transact    com.cognitect.vase.literals/transact
  vase/validate    com.cognitect.vase.literals/validate

--- a/template/project.clj
+++ b/template/project.clj
@@ -9,7 +9,7 @@
 ;
 ; You must not remove this notice, or any other, from this software.
 
-(defproject vase/lein-template "0.9.0"
+(defproject vase/lein-template "0.9.1-SNAPSHOT"
   :description "A Pedestal Service + Vase template."
   :url "https://github.com/pedestal/pedestal"
   :scm "https://github.com/pedestal/pedestal"

--- a/test/com/cognitect/vase/literals_test.clj
+++ b/test/com/cognitect/vase/literals_test.clj
@@ -5,7 +5,8 @@
             [io.pedestal.log :as log]
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.actions :as actions]
-            [clojure.string :as string]))
+            [clojure.string :as string]
+            [io.pedestal.interceptor :as i]))
 
 (deftest test-data-massging
   "This test ensures that data received can be transformed into a form
@@ -42,7 +43,8 @@
       "#vase/redirect" (lit/redirect {:name :redirect :url ""})
       "#vase/validate" (lit/validate {:name :validate})
       "#vase/query"    (lit/query    {:name :query :query []})
-      "#vase/transact" (lit/transact {:name :transact})))
+      "#vase/transact" (lit/transact {:name :transact})
+      "#vase/conform"  (lit/conform  {:name :conform})))
 
   (testing "actions round-trip through the reader"
     (are [action] (= action (read-string (pr-str action)))
@@ -50,4 +52,14 @@
       (lit/redirect {:name :redirect :url ""})
       (lit/validate {:name :validate})
       (lit/query    {:name :query :query []})
-      (lit/transact {:name :transact}))))
+      (lit/transact {:name :transact})
+      (lit/conform  {:name :conform :from :from-key})))
+
+  (testing "literals create IntoInterceptor values"
+    (are [s] (satisfies? i/IntoInterceptor (read-string s))
+      "#vase/respond{:name :a}"
+      "#vase/redirect{:name :b :url \"http://www.example.com\"}"
+      "#vase/validate{:name :c}"
+      "#vase/query{:name :d :query []}"
+      "#vase/transact{:name :e}"
+      "#vase/conform{}")))


### PR DESCRIPTION
* Accesses data from the context map.
* Use the `:from` setting to define which context map value is
  interesting.
* The `:spec` key identifies which spec the data should conform to
* Conformed data will be reattached to the context map under the `:to`
  key
* If conform fails, the explain-data is attached to the context map.
* By default, explain-data gets attaches as
  :com.cognitect.pedestal.vase.actions/explain-data.
* You can override that with the `:explain-to` key.