### PR TITLE
Query action params

### DIFF
--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -310,15 +310,15 @@
         to       (or to ::query-data)]
     `(fn [{~'request :request :as ~'context}]
        (let [~args-sym      (merged-parameters ~'request)
-             vals#          [~(mapcat
-                               (fn [x]
-                                 (let
-                                   [[k-sym default-v] (if (vector? x) x [x nil])
-                                    k (util/ensure-keyword k-sym)]
-                                   (if (contains? coercions k-sym)
-                                   `(coerce-arg-val ~args-sym ~k ~default-v)
-                                   `(get ~args-sym ~k ~default-v))))
-                                variables)]
+             vals#          ~(mapv
+                              (fn [x]
+                                (let
+                                    [[k-sym default-v] (if (vector? x) x [x nil])
+                                     k (util/ensure-keyword k-sym)]
+                                  (if (contains? coercions k-sym)
+                                    `(coerce-arg-val ~args-sym ~k ~default-v)
+                                    `(get ~args-sym ~k ~default-v))))
+                              variables)
              db#            (:db ~'request)
              query-params# (concat vals# ~constants)
              query-result#  (when (every? some? query-params#)

--- a/test/com/cognitect/vase/actions_test.clj
+++ b/test/com/cognitect/vase/actions_test.clj
@@ -133,3 +133,44 @@
           (-> {:query-data {:a 1 :b "string-not-allowed"}}
               (helper/run-interceptor (make-conformer :query-data ::request-body :shaped))
               (get :com.cognitect.vase.actions/explain-data)))))))
+
+(defn get-query-vals
+  "Get the expression that will be bound to vals# in the query"
+  [q-exprs]
+  (-> q-exprs
+      (nth 2)
+      (nth 1)
+      (nth 3)))
+
+(deftest query-action-exprs-test
+  (testing "single parameter is bound correctly"
+    (is
+     (= 1
+        (count
+         (get-query-vals
+          (actions/query-action-exprs
+           '[:find ?e
+             :in $ ?foo
+             :where
+             [?e :foo ?foo]]
+           '[foo]
+           []
+           []
+           {}
+           nil))))))
+  (testing "multiple parameters are bound correctly"
+    (is
+     (= 2
+        (count
+         (get-query-vals
+          (actions/query-action-exprs
+           '[:find ?e
+             :in $ ?foo ?bar
+             :where
+             [?e :foo ?foo]
+             [?e :bar ?bar]]
+           '[foo bar]
+           []
+           []
+           {}
+           nil)))))))


### PR DESCRIPTION
Provides a fix for [#46](https://github.com/cognitect-labs/vase/issues/46)

The use of `mapcat` in `...actions/query-action-exprs` works fine for a single parameter, but causes multiple parameters to be lumped into a single invocation of `...actions/coerce-arg-val`. Using mapv and removing the enclosing vector fixes this.

A test for this specific behaviour was also added to the actions tests.