### PR TITLE
Improve dev experience with schema-tx literal

### DIFF
--- a/src/com/cognitect/vase/literals.clj
+++ b/src/com/cognitect/vase/literals.clj
@@ -11,29 +11,39 @@
 
 ;; Schema literals
 ;; ---------------
-(def accepted-schema-toggles #{:unique :index :fulltext :identity :component nil})
+(def accepted-schema-toggles #{:unique :identity :index :fulltext :component :no-history})
+(def accepted-kinds          #{:keyword :string :boolean :long :bigint :float :double :bigdec :ref :instant :uuid :uri :bytes})
+(def accepted-cards          #{:one :many})
 
-(defn parse-schema-vec [s-vec]
-  (let [doc-string (last s-vec)
-        [ident card kind opt-toggle] (butlast s-vec)]
-    (if (contains? accepted-schema-toggles opt-toggle)
-      (merge {:db/id (d/tempid :db.part/db)
-              :db/ident ident
-              :db/valueType (keyword "db.type" (name kind))
-              :db/cardinality (keyword "db.cardinality" (name card))
-              :db.install/_attribute :db.part/db}
-             (when (string? doc-string)
-              {:db/doc (str doc-string)})
-             (case opt-toggle
-               :unique    {:db/unique :db.unique/value}
-               :identity  {:db/unique :db.unique/identity}
-               :index     {:db/index true}
-               :fulltext  {:db/fulltext true
-                           :db/index true}
-               :component {:db/isComponent true}
-               nil))
-      (throw (ex-info (str "Short schema toggles must be one of: " accepted-schema-toggles)
-                      {:found-toggle opt-toggle})))))
+(defn parse-schema-vec
+  [s-vec]
+  (assert (every? keyword? (butlast s-vec)))
+  (let [doc-string            (last s-vec)
+        [ident card kind & _] (take 3 s-vec)
+        opt-toggles           (take-while keyword? (drop 3 s-vec))]
+    (assert (string? doc-string) (str "The last thing in the vector must be a docstring. Instead, I got a " (type doc-string)))
+    (assert (every? #(contains? accepted-schema-toggles %) opt-toggles)
+            (str "Short schema toggles must be taken from " accepted-schema-toggles ". I found " opt-toggles))
+    (assert (contains? accepted-kinds kind) (str "The value type must be one of " accepted-kinds ". I found " kind))
+    (assert (contains? accepted-cards card) (str "The cardinality must be one of " accepted-cards ". I found " card))
+    (merge {:db/id                 (d/tempid :db.part/db)
+            :db/ident              ident
+            :db/valueType          (keyword "db.type" (name kind))
+            :db/cardinality        (keyword "db.cardinality" (name card))
+            :db.install/_attribute :db.part/db
+            :db/doc                doc-string}
+           (reduce (fn [m opt]
+                     (merge m (case opt
+                                :unique     {:db/unique :db.unique/value}
+                                :identity   {:db/unique :db.unique/identity}
+                                :index      {:db/index true}
+                                :fulltext   {:db/fulltext true
+                                             :db/index    true}
+                                :component  {:db/isComponent true}
+                                :no-history {:db/noHistory true}
+                                nil)))
+                   {}
+                   opt-toggles))))
 
 (defn schema-tx [form]
   {:pre [(vector? form)]}

--- a/test/com/cognitect/vase/literals_test.clj
+++ b/test/com/cognitect/vase/literals_test.clj
@@ -8,6 +8,62 @@
             [clojure.string :as string]
             [io.pedestal.interceptor :as i]))
 
+;; Schema literal tests
+(deftest test-schema-tx
+  (are [input expected] (= expected (map #(dissoc % :db/id) (read-string input)))
+    ;; One attribute
+    "#vase/schema-tx[[:entity/attribute :one :long \"A docstring\"]]"
+    [{:db/ident              :entity/attribute
+      :db/valueType          :db.type/long
+      :db/cardinality        :db.cardinality/one
+      :db/doc                "A docstring"
+      :db.install/_attribute :db.part/db}]
+
+    ;; Two attributes
+    "#vase/schema-tx[[:e/a1 :one :long \"\"] [:e/a2 :many :string \"docstring 2\"]]"
+    [{:db/ident :e/a1
+      :db/valueType :db.type/long
+      :db/cardinality :db.cardinality/one
+      :db/doc ""
+      :db.install/_attribute :db.part/db}
+     {:db/ident              :e/a2
+      :db/valueType          :db.type/string
+      :db/cardinality        :db.cardinality/many
+      :db/doc                "docstring 2"
+      :db.install/_attribute :db.part/db}]
+
+    ;; One toggle
+    "#vase/schema-tx[[:e/a :one :long :identity \"Doc\"]]"
+    [{:db/ident              :e/a
+      :db/valueType          :db.type/long
+      :db/cardinality        :db.cardinality/one
+      :db/unique             :db.unique/identity
+      :db/doc                "Doc"
+      :db.install/_attribute :db.part/db}]
+
+    ;; Several toggles
+    "#vase/schema-tx[[:e/a :one :string :identity :index :component :no-history :fulltext \"Doc\"]]"
+    [{:db/ident              :e/a
+      :db/valueType          :db.type/string
+      :db/cardinality        :db.cardinality/one
+      :db/index              true
+      :db/isComponent        true
+      :db/noHistory          true
+      :db/fulltext           true
+      :db/unique             :db.unique/identity
+      :db/doc                "Doc"
+      :db.install/_attribute :db.part/db}])
+
+  (are [bad-input] (thrown? Throwable (read-string bad-input))
+    "#vase/schema-tx[[:e/a :one-is-the-lonliest-number :long \"doc\"]]"
+    "#vase/schema-tx[[\"not a keyword\" :one :ref \"doc\"]]"
+    "#vase/schema-tx[[:e/a :one :categorically-imperative \"\"]]"
+    "#vase/schema-tx[[:e/a :one :ref]]"
+    "#vase/schema-tx[#{:e/a :one :ref \"doc\"}]"))
+
+(run-tests)
+;; Action literals tests
+;;
 (deftest test-data-massaging
   "This test ensures that data received can be transformed into a form
    amenable to storing into datomic."

--- a/test/com/cognitect/vase/literals_test.clj
+++ b/test/com/cognitect/vase/literals_test.clj
@@ -8,7 +8,7 @@
             [clojure.string :as string]
             [io.pedestal.interceptor :as i]))
 
-(deftest test-data-massging
+(deftest test-data-massaging
   "This test ensures that data received can be transformed into a form
    amenable to storing into datomic."
 


### PR DESCRIPTION
Several minor improvements and one medium-sized change.

* Early, friendly assertions if inputs are not valid.
* Docstring is now required and won't accidentally eat the lost option toggle. (See #44).
* Multiple option toggles can be added in one row.
* New option toggle `:no-history` corresponds to Datomic's `:db/noHistory true`

Fixes #44