### PR TITLE
Update dependencies to use Clojure 1.9.0-alpha17 and clojure.spec.alpha

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,15 @@
   :description "Vase: Pedestal API Container"
   :url "https://github.com/cognitect-labs/pedestal.vase"
   :dependencies [;; Platform
-                 [org.clojure/clojure "1.9.0-alpha14"]
+                 [org.clojure/clojure "1.9.0-alpha17"]
 
                  ;; Datomic
                  [com.datomic/datomic-free "0.9.5554" :exclusions [[org.slf4j/slf4j-api]
                                                                    [org.slf4j/slf4j-nop]]]
                  [io.rkn/conformity "0.4.0" :exclusions [com.datomic/datomic-free]]
+
+                 ;; Tmp. Work around problem also fixed in pedestal.service 0.5.3-SNAPSHOT
+                 [org.clojure/core.async "0.3.443"]
 
                  ;; Pedestal
                  [io.pedestal/pedestal.service "0.5.2"]

--- a/src/com/cognitect/vase.clj
+++ b/src/com/cognitect/vase.clj
@@ -1,5 +1,5 @@
 (ns com.cognitect.vase
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [io.pedestal.http.route :as route]
             [com.cognitect.vase.datomic :as datomic]
             [com.cognitect.vase.literals :as literals]
@@ -51,8 +51,8 @@
 
 (defn specs
   "Given a app-spec or collection of app-specs,
-  extract all defined clojure.specs and evaluate them,
-  placing them in clojure.spec's registry."
+  extract all defined specs and evaluate them,
+  placing them in spec's registry."
   [spec-or-specs]
   (let [edn-specs (if (sequential? spec-or-specs) spec-or-specs [spec-or-specs])
         descriptors (map :descriptor edn-specs)]

--- a/src/com/cognitect/vase.clj
+++ b/src/com/cognitect/vase.clj
@@ -51,8 +51,8 @@
 
 (defn specs
   "Given a app-spec or collection of app-specs,
-  extract all defined specs and evaluate them,
-  placing them in spec's registry."
+  extract all defined clojure.specs and evaluate them,
+  placing them in clojure.spec's registry."
   [spec-or-specs]
   (let [edn-specs (if (sequential? spec-or-specs) spec-or-specs [spec-or-specs])
         descriptors (map :descriptor edn-specs)]

--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -213,7 +213,7 @@
 
 (defn validate-action-exprs
   "Return code for a Pedestal interceptor function that performs
-  spec validation on the parameters."
+  clojure.spec validation on the parameters."
   [params headers spec request-params-path]
   (assert (or (nil? headers) (map? headers)) (str "Headers should be a map. I got " headers))
   `(fn [{~'request :request :as ~'context}]
@@ -223,8 +223,8 @@
            ~(bind params) req-params#
            problems#      (mapv
                            #(dissoc % :pred)
-                           (::s/problems
-                            (s/explain-data ~spec req-params#)))
+                           (:clojure.spec.alpha/problems
+                            (clojure.spec.alpha/explain-data ~spec req-params#)))
            resp#          (util/response
                            problems#
                            ~headers
@@ -239,7 +239,7 @@
   parameters.
 
   The response body will be a list of data structures as returned by
-  spec/explain-data."
+  clojure.spec/explain-data."
   ([name params headers spec]
    (validate-action name params headers spec nil))
   ([name params headers spec request-params-path]

--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -30,7 +30,7 @@
   with \"/users/:userid\", then the s-expression will have the symbol
   `'userid` bound to the value of that request parameter."
   (:require [clojure.walk :as walk]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]
             [io.pedestal.interceptor :as interceptor]
             [com.cognitect.vase.util :as util])
@@ -213,7 +213,7 @@
 
 (defn validate-action-exprs
   "Return code for a Pedestal interceptor function that performs
-  clojure.spec validation on the parameters."
+  spec validation on the parameters."
   [params headers spec request-params-path]
   (assert (or (nil? headers) (map? headers)) (str "Headers should be a map. I got " headers))
   `(fn [{~'request :request :as ~'context}]
@@ -223,8 +223,8 @@
            ~(bind params) req-params#
            problems#      (mapv
                            #(dissoc % :pred)
-                           (:clojure.spec/problems
-                            (clojure.spec/explain-data ~spec req-params#)))
+                           (::s/problems
+                            (s/explain-data ~spec req-params#)))
            resp#          (util/response
                            problems#
                            ~headers
@@ -239,7 +239,7 @@
   parameters.
 
   The response body will be a list of data structures as returned by
-  clojure.spec/explain-data."
+  spec/explain-data."
   ([name params headers spec]
    (validate-action name params headers spec nil))
   ([name params headers spec request-params-path]
@@ -254,15 +254,15 @@
 
 (defn conform-action-exprs
   "Return code for a Pedestal interceptor function that performs
-  clojure.spec validation on the data attached at `from`. If the data
+  spec validation on the data attached at `from`. If the data
   does not conform, the explain-data will be attached at `explain-to`"
   [from spec to explain-to]
   (let [explain-to (or explain-to ::explain-data)]
     `(fn [{~'request :request :as ~'context}]
        (let [val#           (get ~'context ~from)
-             conformed#     (clojure.spec/conform ~spec val#)
-             problems#      (when (= :clojure.spec/invalid conformed#)
-                              (clojure.spec/explain-data ~spec val#))
+             conformed#     (s/conform ~spec val#)
+             problems#      (when (= ::s/invalid conformed#)
+                              (s/explain-data ~spec val#))
              ctx# (assoc ~'context ~to conformed#)]
          (if problems#
            (assoc ctx# ~explain-to problems#)

--- a/src/com/cognitect/vase/spec.clj
+++ b/src/com/cognitect/vase/spec.clj
@@ -1,9 +1,9 @@
 (ns com.cognitect.vase.spec
-  "Contains the clojure.spec definitions for the Vase
+  "Contains the spec definitions for the Vase
    application specification."
   (:require [io.pedestal.interceptor :as interceptor]
-            [clojure.spec :as s]
-            [clojure.spec.gen :as gen]))
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]))
 
 ;; -- Predicates --
 (defn valid-uri?

--- a/src/com/cognitect/vase/spec.clj
+++ b/src/com/cognitect/vase/spec.clj
@@ -1,5 +1,5 @@
 (ns com.cognitect.vase.spec
-  "Contains the spec definitions for the Vase
+  "Contains the clojure.spec definitions for the Vase
    application specification."
   (:require [io.pedestal.interceptor :as interceptor]
             [clojure.spec.alpha :as s]

--- a/template/src/leiningen/new/vase/project.clj
+++ b/template/src/leiningen/new/vase/project.clj
@@ -3,7 +3,7 @@
   :url "http://example.com/FIXME"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha14"]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
                  [io.pedestal/pedestal.service "0.5.2"]
                  [com.cognitect/pedestal.vase "0.9.2-SNAPSHOT"]
 

--- a/template/src/leiningen/new/vase/project.clj
+++ b/template/src/leiningen/new/vase/project.clj
@@ -4,7 +4,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.9.0-alpha17"]
-                 [io.pedestal/pedestal.service "0.5.2"]
+                 ;; Tmp exclusion of core.async only needed until Vase uses Pedestal 0.5.3
+                 [io.pedestal/pedestal.service "0.5.2" :exclusions [org.clojure/core.async]]
                  [com.cognitect/pedestal.vase "0.9.2-SNAPSHOT"]
 
                  ;; Remove this line and uncomment one of the next lines to

--- a/template/src/leiningen/new/vase/vase_service.edn
+++ b/template/src/leiningen/new/vase/vase_service.edn
@@ -25,9 +25,9 @@
   ;; ------------------------
   :vase/specs
   {:{{namespace}}.test/age (fn [age] (> age 21))
-   :{{namespace}}.test/name (clojure.spec/and string? not-empty)
-   :{{namespace}}.test/person (clojure.spec/keys :req-un [:{{namespace}}.test/name
-                                                     :{{namespace}}.test/age])}
+   :{{namespace}}.test/name (clojure.spec.alpha/and string? not-empty)
+   :{{namespace}}.test/person (clojure.spec.alpha/keys :req-un [:{{namespace}}.test/name
+                                                                :{{namespace}}.test/age])}
 
   ;; API Tagged Chunks/Versions
   ;; --------------------------

--- a/test/com/cognitect/vase/conform_test.clj
+++ b/test/com/cognitect/vase/conform_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [com.cognitect.vase.actions :as actions]
             [com.cognitect.vase.test-helper :as helper]
-            [clojure.spec :as s]))
+            [clojure.spec.alpha :as s]))
 
 (s/def ::a string?)
 (s/def ::b boolean?)
@@ -14,13 +14,13 @@
 
 (deftest conform-action
   (testing "Happy path"
-    (is (not= :clojure.spec/invalid
+    (is (not= ::s/invalid
               (-> {:query-data {:a 1 :b true}}
                   (helper/run-interceptor (make-conformer :query-data ::request-body :shaped))
                   (get :shaped)))))
 
   (testing "Non-conforming inputs"
-    (is (= :clojure.spec/invalid
+    (is (= ::s/invalid
            (-> {:query-data {:a 1 :b "string-not-allowed"}}
                (helper/run-interceptor (make-conformer :query-data ::request-body :shaped))
                (get :shaped))))

--- a/test/com/cognitect/vase/query_test.clj
+++ b/test/com/cognitect/vase/query_test.clj
@@ -4,7 +4,7 @@
             [com.cognitect.vase.actions :as actions]
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]))
 
 (defn empty-db-entity-count

--- a/test/com/cognitect/vase/redirect_test.clj
+++ b/test/com/cognitect/vase/redirect_test.clj
@@ -5,7 +5,7 @@
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
             [com.cognitect.vase.actions-test :refer [expect-response with-query-params execute-and-expect]]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]))
 
 (defn make-redirect

--- a/test/com/cognitect/vase/spec_test.clj
+++ b/test/com/cognitect/vase/spec_test.clj
@@ -2,8 +2,8 @@
   (:require [com.cognitect.vase.spec :as vase.spec]
             [com.cognitect.vase :as vase]
             [com.cognitect.vase.service-route-table :as srt]
-            [clojure.spec :as s]
-            [clojure.spec.test :as stest]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]
             [clojure.test :refer :all]
             [io.pedestal.interceptor :as interceptor]))
 

--- a/test/com/cognitect/vase/transaction_test.clj
+++ b/test/com/cognitect/vase/transaction_test.clj
@@ -4,7 +4,7 @@
             [com.cognitect.vase.actions :as actions]
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]
             [io.pedestal.interceptor.chain :as chain]))
 

--- a/test/com/cognitect/vase/validate_test.clj
+++ b/test/com/cognitect/vase/validate_test.clj
@@ -5,7 +5,7 @@
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
             [com.cognitect.vase.actions-test :refer [expect-response with-query-params execute-and-expect]]
-            [clojure.spec :as s]))
+            [clojure.spec.alpha :as s]))
 
 (defn make-validate
   [spec]

--- a/test/resources/test_descriptor.edn
+++ b/test/resources/test_descriptor.edn
@@ -30,9 +30,9 @@
  ;; ------------------------
  :vase/specs
  {:example.test/age (fn [age] (> age 21))
-  :example.test/name (clojure.spec/and string? not-empty)
-  :example.test/person (clojure.spec/keys :req-un [:example.test/name
-                                                   :example.test/age])}
+  :example.test/name (clojure.spec.alpha/and string? not-empty)
+  :example.test/person (clojure.spec.alpha/keys :req-un [:example.test/name
+                                                         :example.test/age])}
 
  ;; API Tags/Versions
  ;; ------------------


### PR DESCRIPTION
Use latest Clojure alpha, for the sake of dependent projects.

Note:
- Required temporary explicit include of the latest core.async, to avoid dragging in all of pedestal.service 0.5.3-SNAPSHOT.
- I did not update any of the sample projects included in this repo. They remain happily depending on earlier versions of everything.