### PR TITLE
Bump Clojure to 1.9.0-alpha17; Use clojure.spec.alpha

### DIFF
--- a/config/sample_descriptor.edn
+++ b/config/sample_descriptor.edn
@@ -16,23 +16,23 @@
   {:vase.norm/requires [:example/base-schema]
    ;; and supports short/basic schema definitions
    :vase.norm/txes [#vase/schema-tx [[:user/userId :one :long :identity "A Users unique identifier"]
-                                            [:user/userEmail :one :string :unique "The users email"]
-                                            ;; :fulltext also implies :index
-                                            [:user/userBio :one :string :fulltext "A short blurb about the user"]]]}
+                                     [:user/userEmail :one :string :unique "The users email"]
+                                     ;; :fulltext also implies :index
+                                     [:user/userBio :one :string :fulltext "A short blurb about the user"]]]}
   :example/loan-schema
   {:vase.norm/requires [:example/base-schema :example/user-schema]
    :vase.norm/txes [#vase/schema-tx [[:loanOffer/loanId :one :long :unique "The unique offer ID"]
-                                            [:loanOffer/fees :one :long :index "All of the loan fees"]
-                                            [:loanOffer/notes :many :string "Notes about the loan"]
-                                            [:user/loanOffers :many :ref "The collection of loan offers"]]]}}
+                                     [:loanOffer/fees :one :long :index "All of the loan fees"]
+                                     [:loanOffer/notes :many :string "Notes about the loan"]
+                                     [:user/loanOffers :many :ref "The collection of loan offers"]]]}}
 
  ;; Global Specs for the API
  ;; ------------------------
  :vase/specs
  {:example.test/age (fn [age] (> age 21))
-  :example.test/name (clojure.spec/and string? not-empty)
-  :example.test/person (clojure.spec/keys :req-un [:example.test/name
-                                                   :example.test/age])}
+  :example.test/name (clojure.spec.alpha/and string? not-empty)
+  :example.test/person (clojure.spec.alpha/keys :req-un [:example.test/name
+                                                         :example.test/age])}
 
  ;; API Tags/Versions
  ;; ------------------

--- a/config/sample_payload.edn
+++ b/config/sample_payload.edn
@@ -17,23 +17,23 @@
    {:vase.norm/requires [:example/base-schema]
     ;; and supports short/basic schema definitions
     :vase.norm/txes [#vase/schema-tx [[:user/userId :one :long :identity "A Users unique identifier"]
-                                            [:user/userEmail :one :string :unique "The users email"]
-                                            ;; :fulltext also implies :index
-                                            [:user/userBio :one :string :fulltext "A short blurb about the user"]]]}
+                                      [:user/userEmail :one :string :unique "The users email"]
+                                      ;; :fulltext also implies :index
+                                      [:user/userBio :one :string :fulltext "A short blurb about the user"]]]}
    :example/loan-schema
    {:vase.norm/requires [:example/base-schema :example/user-schema]
     :vase.norm/txes [#vase/schema-tx [[:loanOffer/loanId :one :long :unique "The unique offer ID"]
-                                            [:loanOffer/fees :one :long :index "All of the loan fees"]
-                                            [:loanOffer/notes :many :string "Notes about the loan"]
-                                            [:user/loanOffers :many :ref "The collection of loan offers"]]]}}
+                                      [:loanOffer/fees :one :long :index "All of the loan fees"]
+                                      [:loanOffer/notes :many :string "Notes about the loan"]
+                                      [:user/loanOffers :many :ref "The collection of loan offers"]]]}}
 
   ;; Global Specs for the API
   ;; ------------------------
   :vase/specs
   {:example.test/age (fn [age] (> age 21))
-   :example.test/name (clojure.spec/and string? not-empty)
-   :example.test/person (clojure.spec/keys :req-un [:example.test/name
-                                                    :example.test/age])}
+   :example.test/name (clojure.spec.alpha/and string? not-empty)
+   :example.test/person (clojure.spec.alpha/keys :req-un [:example.test/name
+                                                          :example.test/age])}
 
   ;; API Tags/Versions
   ;; ------------------

--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "Vase: Pedestal API Container"
   :url "https://github.com/cognitect-labs/pedestal.vase"
   :dependencies [;; Platform
-                 [org.clojure/clojure "1.9.0-alpha14"]
+                 [org.clojure/clojure "1.9.0-alpha17"]
 
                  ;; Datomic
                  [com.datomic/datomic-free "0.9.5554" :exclusions [[org.slf4j/slf4j-api]
@@ -10,11 +10,12 @@
                  [io.rkn/conformity "0.4.0" :exclusions [com.datomic/datomic-free]]
 
                  ;; Pedestal
-                 [io.pedestal/pedestal.service "0.5.2"]
+                 [io.pedestal/pedestal.service "0.5.2" :exclusions [org.clojure/core.async]]
 
                  ;; Cleanup
                  [commons-codec "1.10"]
-                 [cheshire "5.6.3"]]
+                 [cheshire "5.6.3"]
+                 [org.clojure/core.async "0.3.443"]]
   :pedantic? :abort
   :profiles {:srepl {:jvm-opts ^:replace ["-XX:+UseG1GC"
                                           "-Dclojure.server.repl={:port 5555 :accept clojure.core.server/repl}"]}

--- a/samples/omnext-todo/resources/omnext-todo_service.edn
+++ b/samples/omnext-todo/resources/omnext-todo_service.edn
@@ -20,10 +20,10 @@
   ;; ------------------------
   :vase/specs
   {:todo/category keyword?
-   :todo/title (clojure.spec/and string? not-empty)
-   :omnext-todo/todo (clojure.spec/keys :req [:todo/title]
-                                        :opt [:todo/category])
-   :omnext-todo/todos (clojure.spec/+ :omnext-todo/todo)}
+   :todo/title (clojure.spec.alpha/and string? not-empty)
+   :omnext-todo/todo (clojure.spec.alpha/keys :req [:todo/title]
+                                              :opt [:todo/category])
+   :omnext-todo/todos (clojure.spec.alpha/+ :omnext-todo/todo)}
 
   ;; API Tagged Chunks/Versions
   ;; --------------------------
@@ -56,10 +56,10 @@
                                                    :todo/created
                                                    :todo/category
                                                    :todo/completed]}]
-              :delete #vase/transact {:name :omnext-todo.main/todos-delete
-                                      :db-op :vase/retract-entity
-                                      ;; :vase/retract-entity requires :db/id to be supplied
-                                      :properties [:db/id]}}
+               :delete #vase/transact {:name :omnext-todo.main/todos-delete
+                                       :db-op :vase/retract-entity
+                                       ;; :vase/retract-entity requires :db/id to be supplied
+                                       :properties [:db/id]}}
      "/todos/validate" {:post #vase/validate {:name :omnext-todo.main/validate-page
                                               :spec :omnext-todo/todo}}}
     ;:vase.api/interceptors [] ;; Any extra interceptors to apply to this API chunk/version

--- a/samples/pet-store/resources/petstore-simple.edn
+++ b/samples/pet-store/resources/petstore-simple.edn
@@ -9,9 +9,9 @@
                       [:pet-store.pet/tag :one :string "The tag of a pet"]]]}}
   :vase/specs
   {:example.test/age (fn [age] (> age 21))
-   :example.test/name (clojure.spec/and string? not-empty)
-   :example.test/person (clojure.spec/keys :req-un [:example.test/name
-                                                    :example.test/age])}
+   :example.test/name (clojure.spec.alpha/and string? not-empty)
+   :example.test/person (clojure.spec.alpha/keys :req-un [:example.test/name
+                                                          :example.test/age])}
   :vase/apis
   {:pet-store/v1
    {:vase.api/routes {"/pets" {:get #vase/query {:name :pet-store-v1/find-pets

--- a/samples/vase-component/dev/dev.clj
+++ b/samples/vase-component/dev/dev.clj
@@ -7,7 +7,7 @@
    [clojure.reflect :refer [reflect]]
    [clojure.repl :refer [apropos dir doc find-doc pst source]]
    [clojure.set :as set]
-   [clojure.spec :as s]
+   [clojure.spec.alpha :as s]
    [clojure.string :as str]
    [clojure.test :as test]
    [clojure.tools.namespace.repl :refer [refresh refresh-all clear]]

--- a/samples/vase-component/resources/petstore-simple.edn
+++ b/samples/vase-component/resources/petstore-simple.edn
@@ -9,9 +9,9 @@
                       [:pet-store.pet/tag :one :string "The tag of a pet"]]]}}
   :vase/specs
   {:example.test/age (fn [age] (> age 21))
-   :example.test/name (clojure.spec/and string? not-empty)
-   :example.test/person (clojure.spec/keys :req-un [:example.test/name
-                                                    :example.test/age])}
+   :example.test/name (clojure.spec.alpha/and string? not-empty)
+   :example.test/person (clojure.spec.alpha/keys :req-un [:example.test/name
+                                                          :example.test/age])}
   :vase/apis
   {:pet-store/v1
    {:vase.api/routes {"/pets" {:get #vase/query {:name :pet-store-v1/find-pets

--- a/samples/vasebi/resources/vasebi_service.edn
+++ b/samples/vasebi/resources/vasebi_service.edn
@@ -60,7 +60,7 @@
                        :product/type :product.type/produce
                        :product/brand-name "Sweet"}]
 
-                      [{:db/id #db/id[:db.part/user]
+                     [{:db/id #db/id[:db.part/user]
                        :sale/product [:product/name "Ham"]
                        :sale/store [:store/name "JoeMart"]
                        :sale/price 1000}
@@ -84,22 +84,23 @@
   ;; Global Specs for the API
   ;; ------------------------
   :vase/specs
-  {:vasebi.inbound-sale/store (clojure.spec/and string? not-empty)
-   :vasebi.inbound-sale/product (clojure.spec/and string? not-empty)
-   :vasebi.inbound/sale (clojure.spec/keys :req-un [:vasebi.inbound-sale/store
-                                                    :vasebi.inbound-sale/product])
-   :vasebi.inbound/sales (clojure.spec/+ :vasebi.inbound/sale)
+  {:vasebi.inbound-sale/store (clojure.spec.alpha/and string? not-empty)
+   :vasebi.inbound-sale/product (clojure.spec.alpha/and string? not-empty)
+   :vasebi.inbound/sale (clojure.spec.alpha/keys :req-un [:vasebi.inbound-sale/store
+                                                          :vasebi.inbound-sale/product])
+   :vasebi.inbound/sales (clojure.spec.alpha/+ :vasebi.inbound/sale)
 
-   :vasebi.store/name (clojure.spec/and string? not-empty)
-   :vasebi.store/state (clojure.spec/and string? not-empty (fn [x] (= 2 (count x))))
-   :vasebi.store/city (clojure.spec/and string? not-empty)
+   :vasebi.store/name (clojure.spec.alpha/and string? not-empty)
+   :vasebi.store/state (clojure.spec.alpha/and string? not-empty (fn [x] (= 2 (count x))))
+   :vasebi.store/city (clojure.spec.alpha/and string? not-empty)
    :vasebi.store/sqft pos-int?
    :vasebi.store/has-coffee-bar boolean?
-   :vasebi/store (clojure.spec/keys :req-un [:vasebi.store/name
-                                             :vasebi.store/state
-                                             :vasebi.store/city
-                                             :vasebi.store/sqft]
-                                    :opt-un [:vasebi.store/has-coffee-bar])}
+   :vasebi/store (clojure.spec.alpha/keys
+                   :req-un [:vasebi.store/name
+                            :vasebi.store/state
+                            :vasebi.store/city
+                            :vasebi.store/sqft]
+                   :opt-un [:vasebi.store/has-coffee-bar])}
 
   ;; API Tagged Chunks/Versions
   ;; --------------------------
@@ -146,12 +147,12 @@
                                                                    :response
                                                                    {:status 200
                                                                     :body (mapv (fn [res]
-                                                                           (assoc (merge (dissoc (:sale/store res) :db/id)
-                                                                                         (dissoc (:sale/product res) :db/id))
-                                                                                  ;; Let's convert sale prices (whole cents) into floating points
-                                                                                  :sale/price (/ (:sale/price res) 100.0)
-                                                                                  :product/type (get-in res [:sale/product :product/type :db/ident])))
-                                                                         (:vasebi/sales-data ctx))}))}]}}
+                                                                                 (assoc (merge (dissoc (:sale/store res) :db/id)
+                                                                                               (dissoc (:sale/product res) :db/id))
+                                                                                        ;; Let's convert sale prices (whole cents) into floating points
+                                                                                        :sale/price (/ (:sale/price res) 100.0)
+                                                                                        :product/type (get-in res [:sale/product :product/type :db/ident])))
+                                                                           (:vasebi/sales-data ctx))}))}]}}
     ;:vase.api/interceptors [] ;; Any extra interceptors to apply to this API chunk/version
     :vase.api/schemas [:vasebi/foodmart-sales
                        :vasebi/seed-data]

--- a/samples/vasebi/src/vasebi/server.clj
+++ b/samples/vasebi/src/vasebi/server.clj
@@ -1,6 +1,6 @@
 (ns vasebi.server
   (:gen-class) ; for -main method in uberjar
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [io.pedestal.http :as server]
             [io.pedestal.http.route :as route]
             [com.cognitect.vase :as vase]

--- a/src/com/cognitect/vase.clj
+++ b/src/com/cognitect/vase.clj
@@ -1,5 +1,5 @@
 (ns com.cognitect.vase
-  (:require [clojure.spec :as spec]
+  (:require [clojure.spec.alpha :as spec]
             [io.pedestal.http.route :as route]
             [com.cognitect.vase.datomic :as datomic]
             [com.cognitect.vase.literals :as literals]

--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -30,7 +30,7 @@
   with \"/users/:userid\", then the s-expression will have the symbol
   `'userid` bound to the value of that request parameter."
   (:require [clojure.walk :as walk]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]
             [io.pedestal.interceptor :as interceptor]
             [com.cognitect.vase.util :as util])
@@ -137,8 +137,8 @@
              (if-let [v (get params-acc k)]
                (assoc params-acc k (coerce-arg-val v))
                params-acc))
-           req-params
-           coercions))
+          req-params
+          coercions))
 
 (defn bind
   [param-syms]
@@ -169,8 +169,8 @@
     (respond-action-exprs '[url-thing]
                           '[url-thing]
                           '(str "You said: " url-thing " which is a " (type url-thing))
-                          200 {}))
-  )
+                          200 {})))
+
 
 (defn respond-action
   "Return a Pedestal interceptor that responds with a canned
@@ -223,8 +223,8 @@
            ~(bind params) req-params#
            problems#      (mapv
                            #(dissoc % :pred)
-                           (:clojure.spec/problems
-                            (clojure.spec/explain-data ~spec req-params#)))
+                           (:clojure.spec.alpha/problems
+                            (clojure.spec.alpha/explain-data ~spec req-params#)))
            resp#          (util/response
                            problems#
                            ~headers
@@ -239,7 +239,7 @@
   parameters.
 
   The response body will be a list of data structures as returned by
-  clojure.spec/explain-data."
+  clojure.spec.alpha/explain-data."
   ([name params headers spec]
    (validate-action name params headers spec nil))
   ([name params headers spec request-params-path]
@@ -260,9 +260,9 @@
   (let [explain-to (or explain-to ::explain-data)]
     `(fn [{~'request :request :as ~'context}]
        (let [val#           (get ~'context ~from)
-             conformed#     (clojure.spec/conform ~spec val#)
-             problems#      (when (= :clojure.spec/invalid conformed#)
-                              (clojure.spec/explain-data ~spec val#))
+             conformed#     (clojure.spec.alpha/conform ~spec val#)
+             problems#      (when (= :clojure.spec.alpha/invalid conformed#)
+                              (clojure.spec.alpha/explain-data ~spec val#))
              ctx# (assoc ~'context ~to conformed#)]
          (if problems#
            (assoc ctx# ~explain-to problems#)
@@ -360,8 +360,8 @@
                           someone]
                         '[selector]
                         ["mefogus@gmail.com"]
-                        {}))
-  )
+                        {})))
+
 
 (defn query-action
   "Returns a Pedestal interceptor that executes a Datomic query on

--- a/src/com/cognitect/vase/literals.clj
+++ b/src/com/cognitect/vase/literals.clj
@@ -170,10 +170,10 @@
   {:pre [(map? form)
          (:name form)
          (-> form :name keyword?)]}
-   (let [enter (handle-intercept-option (:enter form))
-         leave (handle-intercept-option (:leave form))
-         error (handle-intercept-option (:leave form))]
-     (i/interceptor {:name (:name form)
-                     :enter enter
-                     :leave leave
-                     :error error})))
+  (let [enter (handle-intercept-option (:enter form))
+        leave (handle-intercept-option (:leave form))
+        error (handle-intercept-option (:leave form))]
+    (i/interceptor {:name (:name form)
+                    :enter enter
+                    :leave leave
+                    :error error})))

--- a/src/com/cognitect/vase/spec.clj
+++ b/src/com/cognitect/vase/spec.clj
@@ -2,8 +2,8 @@
   "Contains the clojure.spec definitions for the Vase
    application specification."
   (:require [io.pedestal.interceptor :as interceptor]
-            [clojure.spec :as s]
-            [clojure.spec.gen :as gen]))
+            [clojure.spec.alpha :as s]
+            [clojure.spec.gen.alpha :as gen]))
 
 ;; -- Predicates --
 (defn valid-uri?

--- a/template/src/leiningen/new/vase/vase_service.edn
+++ b/template/src/leiningen/new/vase/vase_service.edn
@@ -25,9 +25,9 @@
   ;; ------------------------
   :vase/specs
   {:{{namespace}}.test/age (fn [age] (> age 21))
-   :{{namespace}}.test/name (clojure.spec/and string? not-empty)
-   :{{namespace}}.test/person (clojure.spec/keys :req-un [:{{namespace}}.test/name
-                                                     :{{namespace}}.test/age])}
+   :{{namespace}}.test/name (clojure.spec.alpha/and string? not-empty)
+   :{{namespace}}.test/person (clojure.spec.alpha/keys :req-un [:{{namespace}}.test/name
+                                                                :{{namespace}}.test/age])}
 
   ;; API Tagged Chunks/Versions
   ;; --------------------------

--- a/test/com/cognitect/vase/conform_test.clj
+++ b/test/com/cognitect/vase/conform_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer :all]
             [com.cognitect.vase.actions :as actions]
             [com.cognitect.vase.test-helper :as helper]
-            [clojure.spec :as s]))
+            [clojure.spec.alpha :as s]))
 
 (s/def ::a string?)
 (s/def ::b boolean?)
@@ -14,13 +14,13 @@
 
 (deftest conform-action
   (testing "Happy path"
-    (is (not= :clojure.spec/invalid
+    (is (not= :clojure.spec.alpha/invalid
               (-> {:query-data {:a 1 :b true}}
                   (helper/run-interceptor (make-conformer :query-data ::request-body :shaped))
                   (get :shaped)))))
 
   (testing "Non-conforming inputs"
-    (is (= :clojure.spec/invalid
+    (is (= :clojure.spec.alpha/invalid
            (-> {:query-data {:a 1 :b "string-not-allowed"}}
                (helper/run-interceptor (make-conformer :query-data ::request-body :shaped))
                (get :shaped))))

--- a/test/com/cognitect/vase/query_test.clj
+++ b/test/com/cognitect/vase/query_test.clj
@@ -4,7 +4,7 @@
             [com.cognitect.vase.actions :as actions]
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]))
 
 (defn empty-db-entity-count
@@ -28,7 +28,7 @@
   ([p]
    (with-path-params {} p))
   ([ctx p]
-      (-> ctx
+   (-> ctx
        (update-in [:request :path-params] merge p)
        (update-in [:request :params] merge p))))
 

--- a/test/com/cognitect/vase/redirect_test.clj
+++ b/test/com/cognitect/vase/redirect_test.clj
@@ -5,7 +5,7 @@
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
             [com.cognitect.vase.actions-test :refer [expect-response with-query-params execute-and-expect]]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]))
 
 (defn make-redirect

--- a/test/com/cognitect/vase/spec_test.clj
+++ b/test/com/cognitect/vase/spec_test.clj
@@ -2,8 +2,8 @@
   (:require [com.cognitect.vase.spec :as vase.spec]
             [com.cognitect.vase :as vase]
             [com.cognitect.vase.service-route-table :as srt]
-            [clojure.spec :as s]
-            [clojure.spec.test :as stest]
+            [clojure.spec.alpha :as s]
+            [clojure.spec.test.alpha :as stest]
             [clojure.test :refer :all]
             [io.pedestal.interceptor :as interceptor]))
 

--- a/test/com/cognitect/vase/transaction_test.clj
+++ b/test/com/cognitect/vase/transaction_test.clj
@@ -4,7 +4,7 @@
             [com.cognitect.vase.actions :as actions]
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
-            [clojure.spec :as s]
+            [clojure.spec.alpha :as s]
             [datomic.api :as d]
             [io.pedestal.interceptor.chain :as chain]))
 

--- a/test/com/cognitect/vase/validate_test.clj
+++ b/test/com/cognitect/vase/validate_test.clj
@@ -5,7 +5,7 @@
             [com.cognitect.vase.test-helper :as helper]
             [com.cognitect.vase.test-db-helper :as db-helper]
             [com.cognitect.vase.actions-test :refer [expect-response with-query-params execute-and-expect]]
-            [clojure.spec :as s]))
+            [clojure.spec.alpha :as s]))
 
 (defn make-validate
   [spec]

--- a/test/resources/test_descriptor.edn
+++ b/test/resources/test_descriptor.edn
@@ -30,9 +30,9 @@
  ;; ------------------------
  :vase/specs
  {:example.test/age (fn [age] (> age 21))
-  :example.test/name (clojure.spec/and string? not-empty)
-  :example.test/person (clojure.spec/keys :req-un [:example.test/name
-                                                   :example.test/age])}
+  :example.test/name (clojure.spec.alpha/and string? not-empty)
+  :example.test/person (clojure.spec.alpha/keys :req-un [:example.test/name
+                                                         :example.test/age])}
 
  ;; API Tags/Versions
  ;; ------------------


### PR DESCRIPTION
- Updated all usage of clojure.spec to clojure.spec.alpha
- Fixed formatting issue (specifically, those causing parinfer trouble)