### PR TITLE
Fix typos in module docstring

### DIFF
--- a/docs/action_literals.md
+++ b/docs/action_literals.md
@@ -5,7 +5,7 @@ full scoop, you should definitely look at
 src/com/cognitect/vase/literals.clj.
 
 All the literals can be chained together in a single route, _except_
-for #vase/respond and #vase/redirect. To chain literals, put them in a vector.
+for `#vase/respond` and `#vase/redirect`, which end a chain. To chain literals, put them in a vector.
 
 
 ## #vase/respond

--- a/src/com/cognitect/vase/actions.clj
+++ b/src/com/cognitect/vase/actions.clj
@@ -5,8 +5,8 @@
   interceptors. These are the main public entry points, and are used
   by the `literals` namespace when loading Vase descriptors.
 
-  Take care to avoid code generation during requst processing. It is
-  time consuming, so it should be done at application startup time
+  Take care to avoid code generation during request processing. It is
+  time-consuming, so it should be done at application startup time
   instead.
 
   Actions are created by emitting code (in the functions named


### PR DESCRIPTION
Just a couple of things that caught my eye.