### PR TITLE
Don't create the app-api description route when the base endpoint is in use

### DIFF
--- a/src/com/cognitect/vase/routes.clj
+++ b/src/com/cognitect/vase/routes.clj
@@ -95,4 +95,10 @@
           app-api-route      (api-description-route app-version-root
                                                     app-version-routes
                                                     (api-description-route-name spec))]
-      (cons app-api-route app-version-routes))))
+      (if (not-any?
+            (fn [route] (and
+                          (= app-version-root (first route))
+                          (= :get (second route))))
+            app-version-routes)
+        (cons app-api-route app-version-routes)
+        app-version-routes))))

--- a/src/com/cognitect/vase/spec.clj
+++ b/src/com/cognitect/vase/spec.clj
@@ -13,7 +13,7 @@
     (boolean (and (string? v) (not-empty v) (java.net.URI. v)))
     (catch java.net.URISyntaxException e false)))
 
-(defn no-duplicates-handlers?
+(defn no-duplicate-handlers?
   "Returns true if there are no two handlers for the same URI and action."
   [route-table]
   (distinct? (map #([(first %) (second %)]) route-table)))
@@ -29,7 +29,7 @@
                                                                             #(instance? java.util.regex.Pattern %))))))
 (s/def ::route-table (s/and
                        (s/* (s/spec ::route-table-route))
-                       no-duplicates-handlers?))
+                       no-duplicate-handlers?))
 
 ;; -- Vase app-specs --
 (s/def ::activated-apis  (s/or :base keyword?

--- a/src/com/cognitect/vase/spec.clj
+++ b/src/com/cognitect/vase/spec.clj
@@ -13,6 +13,11 @@
     (boolean (and (string? v) (not-empty v) (java.net.URI. v)))
     (catch java.net.URISyntaxException e false)))
 
+(defn no-duplicates-handlers?
+  "Returns true if there are no two handlers for the same URI and action."
+  [route-table]
+  (distinct? (map #([(first %) (second %)]) route-table)))
+
 ;; -- Pedestal-specs --
 (s/def ::interceptor #(satisfies? interceptor/IntoInterceptor %))
 (s/def ::route-table-route (s/cat :path valid-uri?
@@ -22,7 +27,9 @@
                             :constraints (s/? (s/cat :_ #(= :constraints %)
                                                      :constraints (s/map-of keyword?
                                                                             #(instance? java.util.regex.Pattern %))))))
-(s/def ::route-table (s/* (s/spec ::route-table-route)))
+(s/def ::route-table (s/and
+                       (s/* (s/spec ::route-table-route))
+                       no-duplicates-handlers?))
 
 ;; -- Vase app-specs --
 (s/def ::activated-apis  (s/or :base keyword?

--- a/test/com/cognitect/vase/service_test.clj
+++ b/test/com/cognitect/vase/service_test.clj
@@ -33,7 +33,7 @@
 
 (def known-route-names
   #{:describe-apis
-    :example.v1/describe
+    :example.v1/index-response
     :example.v1/simple-response
     :example.v1/r-page
     :example.v1/ar-page
@@ -50,8 +50,7 @@
     :example.v1/fogussomeone-page
     :example.v2/describe
     :example.v2/hello
-    :example.v2/intercept
-    :example.v1/index-response})
+    :example.v2/intercept})
 
 (deftest all-route-names-present
   (let [service     (srt/service-map)

--- a/test/com/cognitect/vase/service_test.clj
+++ b/test/com/cognitect/vase/service_test.clj
@@ -50,7 +50,8 @@
     :example.v1/fogussomeone-page
     :example.v2/describe
     :example.v2/hello
-    :example.v2/intercept})
+    :example.v2/intercept
+    :example.v1/index-response})
 
 (deftest all-route-names-present
   (let [service     (srt/service-map)

--- a/test/resources/test_descriptor.edn
+++ b/test/resources/test_descriptor.edn
@@ -39,7 +39,9 @@
  :vase/apis
  {:example/v1
   {:vase.api/routes
-   {"/hello"                {:get #vase/respond {:name :example.v1/simple-response
+   {"/"                     {:get #vase/respond {:name :example.v1/index-response
+                                                 :body "Index"}}
+    "/hello"                {:get #vase/respond {:name :example.v1/simple-response
                                                  :body "Hello World"}}
     "/redirect-to-google"   {:get #vase/redirect {:name :example.v1/r-page
                                                   :url  "http://www.google.com"}}


### PR DESCRIPTION
Related to issue #91 